### PR TITLE
On device start: reset password or access point start

### DIFF
--- a/ESP32/PushPushAirESP32/PushPushAirESP32.ino
+++ b/ESP32/PushPushAirESP32/PushPushAirESP32.ino
@@ -181,13 +181,15 @@ static void SendKey( byte pedal ){
     switch( pedal ){
       case PEDAL1_PIN:
           bleKeyboard.press(key_options[preferences.getInt("pedal1", PEDAL1_DEFAULT_KEY_INDEX)].value);
+          Serial.println(key_options[preferences.getInt("pedal1", PEDAL1_DEFAULT_KEY_INDEX)].label);
       break; 
       case PEDAL2_PIN:
           bleKeyboard.press(key_options[preferences.getInt("pedal2", PEDAL2_DEFAULT_KEY_INDEX)].value);
+          Serial.println(key_options[preferences.getInt("pedal2", PEDAL2_DEFAULT_KEY_INDEX)].label);
       break; 
     }
     
-    Serial.println(key_options[preferences.getInt("pedal2", PEDAL2_DEFAULT_KEY_INDEX)].label);
+    
     delay(100);
     bleKeyboard.releaseAll();
   }
@@ -314,7 +316,7 @@ void setup(void)
     });
     
     
-    // To reset to factory presets press the pedal 1 and pedal 2 while turning on the device
+    // To reset to factory password press the pedal 1 and pedal 2 while turning on the device
     // the status led blinks fast
     // keep the buttons pressed for 5 seconds until the led stays on
     // now the password is reset to the factory one.

--- a/ESP32/PushPushAirESP32/PushPushAirESP32.ino
+++ b/ESP32/PushPushAirESP32/PushPushAirESP32.ino
@@ -144,6 +144,13 @@ String processor(const String& var){
   return String();
 }
 
+int batteryChargeMultiplier(){
+    if( BL.getBatteryChargeLevel() < 1 ){
+        return 1;
+    }
+    return BL.getBatteryChargeLevel();
+    
+}
 String optionsList(byte pedal){
     int selected;
     if( pedal == 1 ){
@@ -220,6 +227,8 @@ void setup(void)
     Serial.print("Ped2: ");
     Serial.println(key_options[preferences.getInt("pedal2", PEDAL2_DEFAULT_KEY_INDEX)].label);
     
+    status_led_off_interval = 100 * batteryChargeMultiplier();
+    // status_led_off_interval = 100 * 1;
     status_led_on_interval = 200;
     status_led_flag = LOW;
     
@@ -405,7 +414,7 @@ void loop(void)
     // Serial.print("Charge level: ");
     // Serial.println(BL.getBatteryChargeLevel());
     // Serial.println("");
-    status_led_off_interval = 100 * BL.getBatteryChargeLevel();
+    status_led_off_interval = 100 * batteryChargeMultiplier();
     bleKeyboard.setBatteryLevel(BL.getBatteryChargeLevel());
   }
 

--- a/ESP32/PushPushAirESP32/PushPushAirESP32.ino
+++ b/ESP32/PushPushAirESP32/PushPushAirESP32.ino
@@ -144,13 +144,13 @@ String processor(const String& var){
   return String();
 }
 
-int batteryChargeMultiplier(){
+int batteryChargeLedOffInterval(){
     if( BL.getBatteryChargeLevel() < 1 ){
-        return 1;
+        return 100;
     }
-    return BL.getBatteryChargeLevel();
-    
+    return 100 * BL.getBatteryChargeLevel();
 }
+
 String optionsList(byte pedal){
     int selected;
     if( pedal == 1 ){
@@ -222,12 +222,12 @@ void setup(void)
     delay(1000);
     digitalWrite(STATUS_LED_PIN, HIGH);
     
-    Serial.print("Ped1: ");
+    Serial.print("Ped1 sends: ");
     Serial.println(key_options[preferences.getInt("pedal1", PEDAL1_DEFAULT_KEY_INDEX)].label);
-    Serial.print("Ped2: ");
+    Serial.print("Ped2 sends: ");
     Serial.println(key_options[preferences.getInt("pedal2", PEDAL2_DEFAULT_KEY_INDEX)].label);
     
-    status_led_off_interval = 100 * batteryChargeMultiplier();
+    status_led_off_interval = batteryChargeLedOffInterval();
     // status_led_off_interval = 100 * 1;
     status_led_on_interval = 200;
     status_led_flag = LOW;
@@ -405,16 +405,12 @@ void loop(void)
 
   if(  millis() > batCheckTime ){
     batCheckTime = millis() + BAT_POLLING_INTERVAL;
-    // Serial.print("Value from pin: ");
-    // Serial.println(analogRead(34));
-    // Serial.print("Average value from pin: ");
-    // Serial.println(BL.pinRead());
-    // Serial.print("Volts: ");
-    // Serial.println(BL.getBatteryVolts());
-    // Serial.print("Charge level: ");
-    // Serial.println(BL.getBatteryChargeLevel());
-    // Serial.println("");
-    status_led_off_interval = 100 * batteryChargeMultiplier();
+    Serial.print("Volts: ");
+    Serial.println(BL.getBatteryVolts());
+    Serial.print("Charge level: ");
+    Serial.println(BL.getBatteryChargeLevel());
+
+    status_led_off_interval = batteryChargeLedOffInterval();
     bleKeyboard.setBatteryLevel(BL.getBatteryChargeLevel());
   }
 

--- a/ESP32/PushPushAirESP32/PushPushAirESP32.ino
+++ b/ESP32/PushPushAirESP32/PushPushAirESP32.ino
@@ -314,42 +314,49 @@ void setup(void)
     });
     
     
-    // To reset to factory presets keep pressed the pedal 1 while turning on the device
-    // then press the pedal 2
+    // To reset to factory presets press the pedal 1 and pedal 2 while turning on the device
+    // the status led blinks fast
+    // keep the buttons pressed for 5 seconds until the led stays on
+    // now the password is reset to the factory one.
+    
     ped_prev.update();
+    ped_next.update();
+    
     long reset_btn_on_time = millis();
-    byte reset_btn_led = 1;
-    byte im_resetting = false;
+    long reset_wait = millis();
+    byte reset_btn_led = HIGH;
+    byte password_reset_done = false;
 
-    while (ped_prev.read() == 0){
-        Serial.println("Waiting for Pedal 2 to start password reset ");
-      digitalWrite(STATUS_LED_PIN, reset_btn_led); 
-      if( millis()-reset_btn_on_time > 200 && !im_resetting ){
-          digitalWrite(STATUS_LED_PIN, !reset_btn_led);
-          reset_btn_led = !reset_btn_led;
-        reset_btn_on_time = millis();
-      }
-       ped_prev.update();
-       ped_next.update();
-
-      if (ped_next.fell()){ // the pedal 2 button was pressed: let's start the reset procedure
-        Serial.println("Starting password reset ");
-         digitalWrite(STATUS_LED_PIN, HIGH); //keep the led on to signal that the reset procedure is starting
-         im_resetting = true; //don't blink animore
-         
-         Serial.println("Reset passowrd to");
-         Serial.println(PASSWORD_DEFAULT);
-         
-         String rpassword = PASSWORD_DEFAULT;
-         const char *wrpassword = rpassword.c_str();
-         preferences.putString("password", wrpassword);
-
-         delay(3000);
-
-         Serial.println("Password reset done");
-         // turn the led off when the write procedure finish
-         digitalWrite(STATUS_LED_PIN, LOW);
-      }
+    if (ped_next.read() == 0 && ped_next.read() == 0){
+        Serial.println("Waiting for password factory reset. Keep the buttons pressed for 5 seconds");
+        
+        while (ped_next.read() == 0 && ped_next.read() == 0 && ! password_reset_done ) {
+            // digitalWrite(STATUS_LED_PIN, reset_btn_led );
+            if( millis() - reset_wait < 5000 ){
+                if( millis()-reset_btn_on_time > 50){
+                    reset_btn_led = !reset_btn_led;
+                    digitalWrite(STATUS_LED_PIN, reset_btn_led);
+                    reset_btn_on_time = millis();
+                    Serial.print(".");
+                }
+            }
+            else{
+                digitalWrite(STATUS_LED_PIN, HIGH); //keep the led on to signal that the reset procedure is starting
+                Serial.println("Reset passowrd to");
+                Serial.println(PASSWORD_DEFAULT);
+                
+                String rpassword = PASSWORD_DEFAULT;
+                const char *wrpassword = rpassword.c_str();
+                preferences.putString("password", wrpassword);
+       
+                delay(2000);
+       
+                Serial.println("Password reset done");
+                password_reset_done = true; 
+                // turn the led off when the write procedure finish
+                digitalWrite(STATUS_LED_PIN, LOW);
+            }
+        }
     }
     
 }

--- a/ESP32/PushPushAirESP32/PushPushAirESP32.ino
+++ b/ESP32/PushPushAirESP32/PushPushAirESP32.ino
@@ -284,6 +284,46 @@ void setup(void)
     
     // Start server
     server.begin();
+    
+    // To reset to factory presets keep pressed the pedal 1 while turning on the device
+    // then press the pedal 2
+    ped_prev.update();
+    long reset_btn_on_time = millis();
+    byte reset_btn_led = 1;
+    byte im_resetting = false;
+
+    while (ped_prev.read() == 0){
+        Serial.println("Waiting for Pedal 2 to start password reset ");
+      digitalWrite(STATUS_LED_PIN, reset_btn_led); 
+      if( millis()-reset_btn_on_time > 200 && !im_resetting ){
+          digitalWrite(STATUS_LED_PIN, !reset_btn_led);
+          reset_btn_led = !reset_btn_led;
+        reset_btn_on_time = millis();
+      }
+       ped_prev.update();
+       ped_next.update();
+
+      if (ped_next.fell()){ // the pedal 2 button was pressed: let's start the reset procedure
+        Serial.println("Starting password reset ");
+         digitalWrite(STATUS_LED_PIN, HIGH); //keep the led on to signal that the reset procedure is starting
+         im_resetting = true; //don't blink animore
+         
+         Serial.println("Reset passowrd to");
+         Serial.println(PASSWORD_DEFAULT);
+         
+         String rpassword = PASSWORD_DEFAULT;
+         const char *wrpassword = rpassword.c_str();
+         preferences.putString("password", wrpassword);
+
+         delay(3000);
+
+         Serial.println("Password reset done");
+         // turn the led off when the write procedure finish
+         digitalWrite(STATUS_LED_PIN, LOW);
+      }
+    }
+    
+    
 }
 
 void loop(void)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ A little (but expandable) battery powered pedalboard that, emulating a Bluethoot
 Made with an ESP32
 Configurable via WiFI (you can choose the keystrokes that you want to send)
 
-##Configuration##
+## Configuration ##
 - Turn on the PPA while pushing the right-most pedal.
 - The status led will be steady blue.
 - Now connect from a computer or mobile device to the wifi network "Push Push AIR" and insert the passord
-- Once the connection is etablished, browse to 192.168.4.1 th use the configuration page.
+- Once the connection is etablished, browse to 192.168.4.1 to use the configuration page.
 
 Libraries used:
 ```
@@ -27,6 +27,6 @@ Libraries used:
  */
  ```
  
- BleKeyboard 0.3.0
+ BleKeyboard 0.3.2beta
  Preferences
  Bounce2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Configurable via WiFI (you can choose the keystrokes that you want to send)
 - Out of the box PushPushAIR is configured to send the key cursor left and right. Check the app that you want to control and, if it needs different keys, go to the Configuration section and change the keystrokes sent.
 
 ## Configuration ##
-- Turn on the PPA while pushing the left-most pedal.
+- Turn on the PPA while pushing the right-most pedal.
 - The status led will be steady blue.
 - Now connect from a computer or mobile device to the wifi network "Push Push AIR" and insert the passord
 - Once the connection is etablished, browse to 192.168.4.1 to use the configuration page.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ A little (but expandable) battery powered pedalboard that, emulating a Bluethoot
 Made with an ESP32
 Configurable via WiFI (you can choose the keystrokes that you want to send)
 
-
+##Configuration##
+- Turn on the PPA while pushing the right-most pedal.
+- The status led will be steady blue.
+- Now connect from a computer or mobile device to the wifi network "Push Push AIR" and insert the passord
+- Once the connection is etablished, browse to 192.168.4.1 th use the configuration page.
 
 Libraries used:
 ```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,42 @@
 # Push Push Air
 
-_[this page is a work in progress, and for the moment it's little more than a notepad... it will become a well documentend Readme aniway, soon or later]_
+_[this page is a work in progress, and for the moment it's little more than a notepad... it will become a well documentend Readme, soon or later]_
 
 A little (but expandable) battery powered pedalboard that, emulating a Bluethooth keyboard, send keystrokes (per example it can turn pages on a PDF reader... ). 
 
 Made with an ESP32
 Configurable via WiFI (you can choose the keystrokes that you want to send)
 
+## Usage ##
+- Turn on your PushPush AIR
+- Go to the Bluethooth manager on your mobile, tablet or computer and start the search for new devices
+- In a few seconds it should appear "PushPushAIR2" (or the new name of the device if you already changed it[see below] )
+- Click/Tap on the discovered PushPushAIR to pair it with your mobile device
+- PushPushAIR will appear and act as a remote Bluethooth keyboard
+- Out of the box PushPushAIR is configured to send the key cursor left and right. Check the app that you want to control and, if it needs different keys, go to the Configuration section and change the keystrokes sent.
+
 ## Configuration ##
-- Turn on the PPA while pushing the right-most pedal.
+- Turn on the PPA while pushing the left-most pedal.
 - The status led will be steady blue.
 - Now connect from a computer or mobile device to the wifi network "Push Push AIR" and insert the passord
 - Once the connection is etablished, browse to 192.168.4.1 to use the configuration page.
-
+- On the configuration page you can set:
+ - The device name that idetify the Push Push AIR on WiFI and Bluethooth (you need to restart the device in order to render effective the name's change)
+ - The passowrd to access the configuration page
+ - The characters sent by the pedals
+ 
+## Reset the password to the factory one ##
+ If you change the password of the Configuration page and you forget it, you can revert to the factory one: `12345678`
+ **How to reset:**
+ - Turn on the PPA while pushing both pedals. The Status led starts blink fast
+ - Keep pressed both the pedals for 5 seconds, untile the Status led turn steady on
+ - Wait 2/3 seconds untile the led turns off.
+ - The reset is now complete. 
+ 
+ 
+ 
+ 
+ 
 Libraries used:
 ```
 /**


### PR DESCRIPTION
To start the access point for the configuration:
turn on PushPush while pushing Pedal 2 (led blinks slowly until the AP is stared, then remains on)

To reset password:
turn on PushPush while pushing Pedal 1 (led blinks fast) then keep Pedal 1 pressed and press the Pedal 2 too (led turns off when password will be reset to the default one)